### PR TITLE
Remove unused import

### DIFF
--- a/src/test/java/com/github/ferstl/xmlbeans/RegexTest.java
+++ b/src/test/java/com/github/ferstl/xmlbeans/RegexTest.java
@@ -1,6 +1,5 @@
 package com.github.ferstl.xmlbeans;
 
-import javax.management.MBeanServerFactory;
 import org.apache.xmlbeans.impl.regex.Match;
 import org.apache.xmlbeans.impl.regex.RegularExpression;
 import org.junit.Test;


### PR DESCRIPTION
The import of MBeanServerFactory is not used and can be removed.